### PR TITLE
fix: remove unverified claims from blaze intelligence page

### DIFF
--- a/blaze-intelligence-index.html
+++ b/blaze-intelligence-index.html
@@ -214,6 +214,26 @@
             opacity: 0.8;
         }
 
+        .compliance-disclaimer {
+            margin-top: 1.5rem;
+            padding: 1rem;
+            border-radius: 12px;
+            background: rgba(10, 10, 15, 0.6);
+            border: 1px solid var(--glass-border);
+            text-align: left;
+        }
+
+        .compliance-disclaimer p {
+            font-size: 0.95rem;
+            line-height: 1.5;
+            opacity: 0.75;
+            margin-bottom: 0.75rem;
+        }
+
+        .compliance-disclaimer p:last-child {
+            margin-bottom: 0;
+        }
+
         /* Dashboard Container */
         .dashboard {
             background: var(--dark);
@@ -1148,8 +1168,12 @@
                         ),
                         React.createElement('h1', { className: 'hero-title' }, '🔥 Blaze Intelligence OS'),
                         React.createElement('h2', { className: 'hero-subtitle' }, 'Championship Sports Analytics'),
-                        React.createElement('p', { className: 'hero-description' }, 
+                        React.createElement('p', { className: 'hero-description' },
                             'Where cognitive performance meets quarterly performance. Advanced analytics platform combining AI-driven insights with championship-level strategic thinking.'
+                        ),
+                        React.createElement('div', { className: 'compliance-disclaimer', role: 'note' },
+                            React.createElement('p', null, 'Blaze Intelligence is an independent concept project. Names, logos, and trademarks remain the property of their respective leagues, teams, and athletes.'),
+                            React.createElement('p', null, 'All analytics shown are illustrative, not sourced from official or real-time data feeds, and should not be interpreted as verified facts or endorsements.')
                         )
                     )
                 ),
@@ -1194,7 +1218,7 @@
                 React.createElement('section', { className: 'dashboard' },
                     React.createElement('div', { className: 'dashboard-header' },
                         React.createElement('h2', { className: 'dashboard-title' }, 'Championship Analytics Dashboard'),
-                        React.createElement('p', { className: 'dashboard-subtitle' }, 'Real-time intelligence across all major sports leagues')
+                        React.createElement('p', { className: 'dashboard-subtitle' }, 'High-level intelligence snapshots across major sports leagues')
                     ),
 
                     // Analytics Overview
@@ -1348,11 +1372,11 @@
                                                 target: '_blank', 
                                                 className: 'link-button twitter-link' 
                                             }, 'Twitter'),
-                                            Object.keys(player.Links).length > 2 && React.createElement('a', { 
-                                                href: Object.values(player.Links)[2], 
-                                                target: '_blank', 
-                                                className: 'link-button official-link' 
-                                            }, player.Sport === 'MLB' ? 'MLB' : player.Sport === 'NFL' ? 'NFL' : player.Sport === 'NBA' ? 'NBA' : 'Official')
+                                            Object.keys(player.Links).length > 2 && React.createElement('a', {
+                                                href: Object.values(player.Links)[2],
+                                                target: '_blank',
+                                                className: 'link-button official-link'
+                                            }, player.Sport === 'MLB' ? 'MLB' : player.Sport === 'NFL' ? 'NFL' : player.Sport === 'NBA' ? 'NBA' : 'League Profile')
                                         )
                                     )
                                 )
@@ -1412,14 +1436,14 @@
                                                 target: '_blank', 
                                                 className: 'link-button twitter-link' 
                                             }, 'Twitter'),
-                                            React.createElement('a', { 
+                                            React.createElement('a', {
                                                 href: team['League/Sport'] === 'MLB' ? `https://www.mlb.com/team/${team.Team.toLowerCase().replace(/\s+/g, '-')}/` :
                                                       team['League/Sport'] === 'NFL' ? `https://www.nfl.com/teams/${team.Team.toLowerCase().replace(/\s+/g, '-')}/` :
                                                       team['League/Sport'] === 'NBA' ? `https://www.nba.com/team/${team.Team.toLowerCase().replace(/\s+/g, '')}/` :
-                                                      `https://www.google.com/search?q=${encodeURIComponent(team.Team + ' ' + team['League/Sport'])}`, 
-                                                target: '_blank', 
-                                                className: 'link-button official-link' 
-                                            }, 'Official')
+                                                      `https://www.google.com/search?q=${encodeURIComponent(team.Team + ' ' + team['League/Sport'])}`,
+                                                target: '_blank',
+                                                className: 'link-button official-link'
+                                            }, 'League Website')
                                         )
                                     );
                                 })
@@ -1451,7 +1475,7 @@
                                 React.createElement('p', null, selectedTeam.Notes)
                             ),
                             selectedTeam.Analytics?.proprietaryMetrics && React.createElement('div', { className: 'modal-section' },
-                                React.createElement('h3', null, 'Proprietary Metrics'),
+                                React.createElement('h3', null, 'Custom Metrics'),
                                 React.createElement('div', { className: 'proprietary-metrics' },
                                     selectedTeam.Analytics.proprietaryMetrics.map((metric, index) =>
                                         React.createElement('div', { key: index, className: 'proprietary-item' },
@@ -1476,15 +1500,15 @@
                                         className: 'link-button twitter-link',
                                         style: { minWidth: '120px', textAlign: 'center' }
                                     }, 'Twitter Feed'),
-                                    React.createElement('a', { 
+                                    React.createElement('a', {
                                         href: selectedTeam['League/Sport'] === 'MLB' ? `https://www.mlb.com/team/${selectedTeam.Team.toLowerCase().replace(/\s+/g, '-')}/` :
                                               selectedTeam['League/Sport'] === 'NFL' ? `https://www.nfl.com/teams/${selectedTeam.Team.toLowerCase().replace(/\s+/g, '-')}/` :
                                               selectedTeam['League/Sport'] === 'NBA' ? `https://www.nba.com/team/${selectedTeam.Team.toLowerCase().replace(/\s+/g, '')}/` :
-                                              `https://www.google.com/search?q=${encodeURIComponent(selectedTeam.Team + ' ' + selectedTeam['League/Sport'])}`, 
-                                        target: '_blank', 
+                                              `https://www.google.com/search?q=${encodeURIComponent(selectedTeam.Team + ' ' + selectedTeam['League/Sport'])}`,
+                                        target: '_blank',
                                         className: 'link-button official-link',
                                         style: { minWidth: '120px', textAlign: 'center' }
-                                    }, 'Official Site')
+                                    }, 'League Website')
                                 )
                             )
                         )
@@ -1544,12 +1568,12 @@
                                         className: 'link-button twitter-link',
                                         style: { textAlign: 'center', minWidth: '100px' }
                                     }, 'Follow on Twitter'),
-                                    Object.keys(selectedPlayer.Links).length > 2 && React.createElement('a', { 
-                                        href: Object.values(selectedPlayer.Links)[2], 
-                                        target: '_blank', 
+                                    Object.keys(selectedPlayer.Links).length > 2 && React.createElement('a', {
+                                        href: Object.values(selectedPlayer.Links)[2],
+                                        target: '_blank',
                                         className: 'link-button official-link',
                                         style: { textAlign: 'center', minWidth: '100px' }
-                                    }, selectedPlayer.Sport === 'MLB' ? 'MLB Profile' : selectedPlayer.Sport === 'NFL' ? 'NFL Profile' : selectedPlayer.Sport === 'NBA' ? 'NBA Profile' : 'Official Site')
+                                    }, selectedPlayer.Sport === 'MLB' ? 'MLB Profile' : selectedPlayer.Sport === 'NFL' ? 'NFL Profile' : selectedPlayer.Sport === 'NBA' ? 'NBA Profile' : 'League Profile')
                                 )
                             )
                         )


### PR DESCRIPTION
## Summary
- add compliance disclaimer clarifying Blaze Intelligence is an independent concept with illustrative data only
- tone down marketing copy and link labels to avoid implying official partnerships or real-time feeds
- rename proprietary metrics section to custom metrics for accurate terminology

## Testing
- not run (static content update)

------
https://chatgpt.com/codex/tasks/task_e_68d46e300c3c8330b5da63c7e26220b9