### PR TITLE
fix: use relative homepage for production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "serve": "npx serve -s build",
     "clean": "rm -rf build node_modules/.cache"
   },
-  "homepage": "https://ahump20.github.io/austin-humphrey-portfolio",
+  "homepage": ".",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ahump20/austin-humphrey-portfolio.git"


### PR DESCRIPTION
## Summary
- point the CRA homepage setting to a relative path so bundled assets resolve on custom domains

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d52b8443008330b551acb303df6cd1